### PR TITLE
Persist active chapter selection across views

### DIFF
--- a/components/workspace/ChapterKanbanView.tsx
+++ b/components/workspace/ChapterKanbanView.tsx
@@ -15,6 +15,8 @@ const ChapterCard: React.FC<ChapterCardProps> = ({ chapter, onSelect }) => {
     // FIX: Select actions individually to prevent re-renders from new object references.
     const updateChapter = useBookCraftStore(state => state.updateChapter);
     const deleteChapter = useBookCraftStore(state => state.deleteChapter);
+    const setActiveChapter = useBookCraftStore(state => state.setActiveChapter);
+    const clearActiveChapter = useBookCraftStore(state => state.clearActiveChapter);
 
     const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         e.stopPropagation();
@@ -25,13 +27,19 @@ const ChapterCard: React.FC<ChapterCardProps> = ({ chapter, onSelect }) => {
         e.stopPropagation();
         if (window.confirm(`Are you sure you want to delete "${chapter.title}"?`)) {
             deleteChapter(chapter.id);
+            if (useBookCraftStore.getState().activeChapterId === chapter.id) {
+                clearActiveChapter();
+            }
         }
     };
 
     return (
         <Card
             className="mb-3 cursor-pointer bg-gray-100 hover:bg-white/50 hover:border-brand-primary"
-            onClick={() => onSelect(chapter.id)}
+            onClick={() => {
+                setActiveChapter(chapter.id);
+                onSelect(chapter.id);
+            }}
         >
             <div className="p-4">
                 <div className="flex justify-between items-start">

--- a/components/workspace/ChapterListView.tsx
+++ b/components/workspace/ChapterListView.tsx
@@ -150,6 +150,8 @@ export const ChapterListView: React.FC<ChapterListViewProps> = ({ activeChapterI
     // FIX: Select the raw chapters array to prevent re-renders.
     const rawChapters = useBookCraftStore(state => state.projects[state.activeProjectId!]?.chapters || []);
     const reorderChapters = useBookCraftStore(state => state.reorderChapters);
+    const setActiveChapter = useBookCraftStore(state => state.setActiveChapter);
+    const clearActiveChapter = useBookCraftStore(state => state.clearActiveChapter);
 
     const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
     const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null);
@@ -165,14 +167,21 @@ export const ChapterListView: React.FC<ChapterListViewProps> = ({ activeChapterI
     
     const handleDeleteChapter = (chapterId: string) => {
         deleteChapter(chapterId);
-        // If the deleted chapter was active, clear the selection
         if (chapterId === activeChapterId) {
-            // Select the first remaining chapter if available
             const remainingChapters = chapters.filter(c => c.id !== chapterId);
             if (remainingChapters.length > 0) {
-                onChapterSelect(remainingChapters[0].id);
+                const nextId = remainingChapters[0].id;
+                setActiveChapter(nextId);
+                onChapterSelect(nextId);
+            } else {
+                clearActiveChapter();
             }
         }
+    };
+
+    const handleSelectChapter = (chapterId: string) => {
+        setActiveChapter(chapterId);
+        onChapterSelect(chapterId);
     };
     
     const handleStatusChange = (chapterId: string, status: ChapterStatus) => {
@@ -228,7 +237,7 @@ export const ChapterListView: React.FC<ChapterListViewProps> = ({ activeChapterI
                             chapter={chap}
                             index={index}
                             isActive={chap.id === activeChapterId}
-                            onSelect={onChapterSelect}
+                            onSelect={handleSelectChapter}
                             onDelete={handleDeleteChapter}
                             onStatusChange={handleStatusChange}
                             isDragged={draggedIndex === index}

--- a/components/workspace/WritingDesk.tsx
+++ b/components/workspace/WritingDesk.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useBookCraftStore } from '../../store/useStore';
 import { ChapterKanbanView } from './ChapterKanbanView';
 import { ChapterListView } from './ChapterListView';
@@ -17,28 +17,38 @@ type ViewMode = 'list' | 'kanban';
 export const WritingDesk: React.FC = () => {
     const [viewMode, setViewMode] = useState<ViewMode>('list');
     const chapters = useBookCraftStore(state => state.projects[state.activeProjectId!]?.chapters || []);
-    const [selectedChapterId, setSelectedChapterId] = useState<string | null>(null);
+    const storedActiveChapterId = useBookCraftStore(state => state.activeChapterId);
+    const setActiveChapter = useBookCraftStore(state => state.setActiveChapter);
+    const clearActiveChapter = useBookCraftStore(state => state.clearActiveChapter);
     const [isPlannerOpen, setIsPlannerOpen] = useState(false);
     const [isResearchOpen, setIsResearchOpen] = useState(false);
     const [isTemplatesOpen, setIsTemplatesOpen] = useState(false);
 
     // FIX: Refactored active chapter logic to be more declarative and robust.
     // This solves the bug where the editor wouldn't appear after generating chapters.
+    const sortedChapters = useMemo(() => [...chapters].sort((a, b) => a.order - b.order), [chapters]);
+
     const activeChapterId = useMemo(() => {
-        // If the user has selected a chapter and it still exists, keep it.
-        if (selectedChapterId && chapters.some(c => c.id === selectedChapterId)) {
-            return selectedChapterId;
+        if (storedActiveChapterId && sortedChapters.some(c => c.id === storedActiveChapterId)) {
+            return storedActiveChapterId;
         }
-        // If there's no valid selection but chapters exist, default to the first one.
-        if (chapters.length > 0) {
-            return [...chapters].sort((a, b) => a.order - b.order)[0].id;
+        if (sortedChapters.length > 0) {
+            return sortedChapters[0].id;
         }
-        // Otherwise, no chapter is active.
         return null;
-    }, [chapters, selectedChapterId]);
+    }, [sortedChapters, storedActiveChapterId]);
+
+    useEffect(() => {
+        if (activeChapterId && activeChapterId !== storedActiveChapterId) {
+            setActiveChapter(activeChapterId);
+        }
+        if (!activeChapterId && storedActiveChapterId) {
+            clearActiveChapter();
+        }
+    }, [activeChapterId, storedActiveChapterId, setActiveChapter, clearActiveChapter]);
 
     const handleChapterSelect = (id: string) => {
-        setSelectedChapterId(id);
+        setActiveChapter(id);
     };
 
     const ViewToggle: React.FC = () => (
@@ -88,7 +98,7 @@ export const WritingDesk: React.FC = () => {
                     </div>
                 </div>
                 <ChapterKanbanView onChapterSelect={(id) => {
-                    setSelectedChapterId(id);
+                    setActiveChapter(id);
                     setViewMode('list');
                 }} />
 

--- a/store/useStore.ts
+++ b/store/useStore.ts
@@ -62,6 +62,7 @@ import { log } from '../services/logger';
 interface BookCraftState {
     projects: Record<string, Project>;
     activeProjectId: string | null;
+    activeChapterId: string | null;
     isCreateModalOpen: boolean;
     isLoading: boolean; // For global loading like analysis
     generatingVisualFor: string | null; // ID of recommendation being generated
@@ -147,6 +148,8 @@ interface BookCraftActions {
     updateProject: (id: string, updates: Partial<Pick<Project, 'title' | 'genre' | 'visualStyle' | 'status'>>) => void;
     deleteProject: (id: string) => void;
     setActiveProject: (id: string | null) => void;
+    setActiveChapter: (chapterId: string | null) => void;
+    clearActiveChapter: () => void;
     toggleCreateModal: (isOpen: boolean) => void;
     closeAllModals: () => void;
     initializeApp: () => void;
@@ -332,6 +335,7 @@ export const useBookCraftStore = create<BookCraftState & BookCraftActions>()(
             // STATE
             projects: {} as Record<string, Project>,
             activeProjectId: null,
+            activeChapterId: null,
             isCreateModalOpen: false,
             isLoading: false,
             generatingVisualFor: null,
@@ -467,10 +471,19 @@ export const useBookCraftStore = create<BookCraftState & BookCraftActions>()(
                     if (state.activeProjectId === id) {
                         state.activeProjectId = null;
                     }
+                    if (state.activeChapterId) {
+                        state.activeChapterId = null;
+                    }
                 });
             },
             setActiveProject: (id) => {
                 set({ activeProjectId: id });
+            },
+            setActiveChapter: (chapterId) => {
+                set({ activeChapterId: chapterId });
+            },
+            clearActiveChapter: () => {
+                set({ activeChapterId: null });
             },
             toggleCreateModal: (isOpen) => {
                 set((state) => {
@@ -737,10 +750,13 @@ export const useBookCraftStore = create<BookCraftState & BookCraftActions>()(
             deleteChapter: (chapterId) => {
                 const projectId = get().activeProjectId;
                 if (!projectId) return;
-                 set(state => {
+                set(state => {
                     const project = state.projects[projectId];
                     if (project) {
                         project.chapters = project.chapters.filter(c => c.id !== chapterId);
+                    }
+                    if (state.activeChapterId === chapterId) {
+                        state.activeChapterId = null;
                     }
                 });
             },
@@ -2781,6 +2797,7 @@ export const useBookCraftStore = create<BookCraftState & BookCraftActions>()(
                 // ONLY persist data, NEVER persist UI state
                 projects: state.projects,
                 activeProjectId: state.activeProjectId,
+                activeChapterId: state.activeChapterId,
                 settings: state.settings,
                 // Persist analytics data
                 writingSessions: state.writingSessions,


### PR DESCRIPTION
## Summary
- add an activeChapterId field to the persisted store along with setter and clearer helpers
- refactor the writing desk to source the active chapter from the store with fallback when no stored chapter exists
- update the chapter list and kanban views to update the shared active chapter selection on user interaction

## Testing
- npm run build *(fails: SettingsModal.tsx has mismatched form/fragment tags prior to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e407160b64832fb87ae7a9ee37b8e4