### PR TITLE
Fix SettingsModal form closing tags and metadata fallback

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -317,7 +317,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                                         />
                                     </div>
                                 </div>
-                            </>
+                            </form>
                         )}
 
                         {/* AI Models Tab */}
@@ -361,7 +361,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                                         </div>
                                     </div>
                                 </div>
-                            </form>
+                            </>
                         )}
 
                         {/* Storage Tab */}

--- a/components/workspace/KDPCalculator.tsx
+++ b/components/workspace/KDPCalculator.tsx
@@ -15,6 +15,21 @@ type BookBinding = 'paperback' | 'hardcover';
 type PaperType = 'white' | 'cream' | 'color';
 type Genre = 'fiction' | 'non-fiction' | 'poetry' | 'children' | 'textbook' | 'other';
 
+const GENRE_OPTIONS: { value: Genre; label: string }[] = [
+    { value: 'fiction', label: 'Fiction' },
+    { value: 'non-fiction', label: 'Non-Fiction' },
+    { value: 'poetry', label: 'Poetry' },
+    { value: 'children', label: "Children's" },
+    { value: 'textbook', label: 'Textbook' },
+    { value: 'other', label: 'Other' }
+];
+
+const PAPER_TYPE_OPTIONS: { value: PaperType; label: string }[] = [
+    { value: 'white', label: 'White (Standard)' },
+    { value: 'cream', label: 'Cream (Classic)' },
+    { value: 'color', label: 'Color (Premium)' }
+];
+
 interface PaperDimensions {
     width: number;
     height: number;
@@ -150,6 +165,15 @@ export const KDPCalculator: React.FC = () => {
     const [listPrice, setListPrice] = useState<number>(12.99);
     const [selectedGenre, setSelectedGenre] = useState<Genre>('fiction');
     const [activeTab, setActiveTab] = useState<'margins' | 'cover' | 'royalty' | 'spine' | 'guidelines'>('guidelines');
+
+    const paperSizeOptions = useMemo(
+        () =>
+            Object.entries(PAPER_SIZES).map(([key, size]) => ({
+                value: key as PaperSize,
+                label: `${size.name}${size.recommended ? ' ⭐' : ''}`
+            })),
+        []
+    );
 
     const dimensions = PAPER_SIZES[paperSize] || PAPER_SIZES['6x9'];
 
@@ -592,18 +616,13 @@ export const KDPCalculator: React.FC = () => {
                 <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
                     <div>
                         <label className="block text-sm font-medium mb-2">Genre</label>
-                        <Select 
-                            value={selectedGenre} 
-                            onChange={(e) => setSelectedGenre(e.target.value as Genre)}
+                        <Select
+                            value={selectedGenre}
+                            onChange={(value) => setSelectedGenre(value as Genre)}
+                            options={GENRE_OPTIONS}
+                            placeholder="Select a genre"
                             className="w-full"
-                        >
-                            <option value="fiction">Fiction</option>
-                            <option value="non-fiction">Non-Fiction</option>
-                            <option value="poetry">Poetry</option>
-                            <option value="children">Children's</option>
-                            <option value="textbook">Textbook</option>
-                            <option value="other">Other</option>
-                        </Select>
+                        />
                     </div>
                     <div>
                         <label className="block text-sm font-medium mb-2">
@@ -615,19 +634,15 @@ export const KDPCalculator: React.FC = () => {
                                 <span className="text-orange-400 text-xs ml-1">(Check genre fit)</span>
                             )}
                         </label>
-                        <Select 
-                            value={paperSize} 
-                            onChange={(e) => setPaperSize(e.target.value as PaperSize)}
+                        <Select
+                            value={paperSize}
+                            onChange={(value) => setPaperSize(value as PaperSize)}
+                            options={paperSizeOptions}
+                            placeholder="Select a paper size"
                             className={`w-full ${
                                 !dimensions.genre.includes(selectedGenre) ? 'border-orange-400/50' : ''
                             }`}
-                        >
-                            {Object.entries(PAPER_SIZES).map(([key, size]) => (
-                                <option key={key} value={key}>
-                                    {size.name} {size.recommended ? '⭐' : ''}
-                                </option>
-                            ))}
-                        </Select>
+                        />
                     </div>
                     <div>
                         <label className="block text-sm font-medium mb-2">
@@ -658,15 +673,13 @@ export const KDPCalculator: React.FC = () => {
                                 <span className="text-amber-400 text-xs ml-1">(Higher cost)</span>
                             )}
                         </label>
-                        <Select 
-                            value={paperType} 
-                            onChange={(e) => setPaperType(e.target.value as PaperType)}
+                        <Select
+                            value={paperType}
+                            onChange={(value) => setPaperType(value as PaperType)}
+                            options={PAPER_TYPE_OPTIONS}
+                            placeholder="Select a paper type"
                             className="w-full"
-                        >
-                            <option value="white">White (Standard)</option>
-                            <option value="cream">Cream (Classic)</option>
-                            <option value="color">Color (Premium)</option>
-                        </Select>
+                        />
                     </div>
                     <div>
                         <label className="block text-sm font-medium mb-2">

--- a/store/useStore.ts
+++ b/store/useStore.ts
@@ -2293,57 +2293,88 @@ export const useBookCraftStore = create<BookCraftState & BookCraftActions>()(
                 try {
                     return await materialFileManager.extractFileMetadata(file);
                 } catch (error) {
-                    log.warn('Failed to extract file metadata', error as Error);
-                    return {};
-                            });
-                            
-                            if (file.type.startsWith('video/')) {
-                                (element as HTMLVideoElement).src = url;
-                            }
-                            
-                            // Timeout after 10 seconds
-                            setTimeout(() => {
+                    log.warn('Failed to extract file metadata via manager, using fallback', error as Error);
+                }
+
+                const metadata: Record<string, unknown> = {};
+
+                try {
+                    metadata.dateCreated = new Date(file.lastModified);
+                } catch (error) {
+                    // Ignore date extraction errors
+                }
+
+                if (file.type.startsWith('image/')) {
+                    try {
+                        const dimensions = await new Promise<{ width: number; height: number }>((resolve, reject) => {
+                            const reader = new FileReader();
+                            reader.onload = () => {
+                                const image = new Image();
+                                image.onload = () => resolve({ width: image.width, height: image.height });
+                                image.onerror = () => reject(new Error('Failed to load image dimensions'));
+                                image.src = reader.result as string;
+                            };
+                            reader.onerror = () => reject(new Error('Failed to read image for dimensions'));
+                            reader.readAsDataURL(file);
+                        });
+
+                        metadata.dimensions = dimensions;
+                    } catch (error) {
+                        // Ignore failures when extracting dimensions
+                    }
+                } else if (file.type.startsWith('video/') || file.type.startsWith('audio/')) {
+                    try {
+                        const duration = await new Promise<number>((resolve) => {
+                            const element = document.createElement(file.type.startsWith('video/') ? 'video' : 'audio');
+                            element.preload = 'metadata';
+                            const url = URL.createObjectURL(file);
+
+                            const cleanup = () => {
                                 URL.revokeObjectURL(url);
+                                element.src = '';
+                            };
+
+                            element.onloadedmetadata = () => {
+                                resolve(Number.isFinite(element.duration) ? element.duration : 0);
+                                cleanup();
+                            };
+
+                            element.onerror = () => {
                                 resolve(0);
+                                cleanup();
+                            };
+
+                            element.src = url;
+
+                            // Timeout in case metadata never loads
+                            setTimeout(() => {
+                                resolve(0);
+                                cleanup();
                             }, 10000);
                         });
-                        
+
                         metadata.duration = duration;
-                        
-                        if (file.type.startsWith('video/')) {
-                            // Extract additional video metadata if possible
-                            metadata.format = file.type;
-                        }
                     } catch (error) {
                         metadata.duration = 0;
                     }
                 } else if (file.type === 'application/pdf') {
-                    // For PDF files, try to extract basic information
-                    try {
-                        metadata.format = 'PDF';
-                        metadata.fileType = 'document';
-                    } catch (error) {
-                        // Ignore errors
-                    }
-                } else if (file.type.includes('text') || file.name.match(/\.(txt|md|rtf)$/i)) {
-                    // For text files, calculate word count
+                    metadata.fileType = 'document';
+                } else if (file.type.includes('text') || /\.(txt|md|rtf)$/i.test(file.name)) {
                     try {
                         const text = await new Promise<string>((resolve, reject) => {
                             const reader = new FileReader();
-                            reader.onload = () => resolve(reader.result as string);
-                            reader.onerror = reject;
+                            reader.onload = () => resolve((reader.result as string) ?? '');
+                            reader.onerror = () => reject(new Error('Failed to read text file'));
                             reader.readAsText(file);
                         });
-                        
+
                         metadata.wordCount = text.split(/\s+/).filter(word => word.length > 0).length;
-                        metadata.characterCount = text.length;
-                        metadata.lineCount = text.split('\n').length;
                     } catch (error) {
-                        // Ignore errors
+                        // Ignore text parsing errors
                     }
                 }
-                
-                return metadata;
+
+                return metadata as Partial<MaterialItem['metadata']>;
             },
 
             // AI Process tracking


### PR DESCRIPTION
## Summary
- close the Settings modal API form correctly while keeping the models tab as a fragment to resolve the build-time markup error
- add a fallback metadata extraction path in the store when the material file manager import fails, covering common media types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4071645d4832fbfe207875458f612